### PR TITLE
Use Properties class for parsing sink properties

### DIFF
--- a/src/main/scala/com/datamountaineer/connect/tools/Cli.scala
+++ b/src/main/scala/com/datamountaineer/connect/tools/Cli.scala
@@ -1,7 +1,11 @@
 package com.datamountaineer.connect.tools
 
-import java.io.{PrintWriter, StringWriter}
+import java.io.{PrintWriter, StringReader, StringWriter}
+import java.util.Properties
+
 import scopt._
+
+import scala.collection.JavaConverters
 
 /** Enumeration of CLI commands */
 object AppCommand extends Enumeration {
@@ -97,19 +101,18 @@ object ExecuteCommand {
       x != null
     })
 
-  /** Regex that is used in propsToMap */
-  lazy val keyValueRegex = "^([^#][^=]*)=(.*)$".r
-
   /**
-    * Translates .properties key values into a String->String map using a regex. Lines starting with # are ignored.
+    * Translates .properties key values into a String->String map. Lines starting with # are ignored.
     *
     * @param properties the lines containing the properties
     * @return a map with key -> value
     */
-  def propsToMap(properties: Seq[String]): Map[String, String] = properties.flatMap(_ match {
-    case keyValueRegex(k, v) => Some((k.trim, v.trim))
-    case _ => None
-  }).toMap
+  def propsToMap(properties: Seq[String]): Map[String, String] = {
+    val joined = properties.mkString("\n")
+    val props = new Properties()
+    props.load(new StringReader(joined))
+    JavaConverters.propertiesAsScalaMapConverter(props).asScala.toMap
+  }
 
 }
 

--- a/src/test/scala/com/datamountaineer/connect/tools/Test.scala
+++ b/src/test/scala/com/datamountaineer/connect/tools/Test.scala
@@ -160,27 +160,19 @@ class ApiUnitTests extends FunSuite with Matchers with MockFactory {
     ret.get.error_count shouldEqual valid.error_count
     ret.get.configs.head.definition.name shouldEqual valid.configs.head.definition.name
   }
+}
 
-  test("regex") {
-    /** Regex that is used in propsToMap */
-    lazy val keyValueRegex = "^([^#][^=]*)=(.*)$".r
+class ExecuteCommandTest extends FunSuite with Matchers {
+  test("properties") {
+    val lines = List(
+      "some.key=\\",
+      "  val1,\\",
+      "  val2"
+    )
 
-    /**
-      * Translates .properties key values into a String->String map using a regex. Lines starting with # are ignored.
-      *
-      * @param properties the lines containing the properties
-      * @return a map with key -> value
-      */
-    def propsToMap(properties: Seq[String]): Map[String, String] = properties.flatMap(_ match {
-      case keyValueRegex(k, v) => Some((k.trim, v.trim))
-      case _ => None
-    }).toMap
+    val cmd = ExecuteCommand
+    val props = cmd.propsToMap(lines)
 
-
-    val p = Seq("test=b=andrew")
-    val m = propsToMap(p)
-    m.head._1 shouldEqual "test"
-    m.head._2 shouldEqual "b=andrew"
+    props.get("some.key") shouldEqual Some("val1,val2")
   }
-
 }


### PR DESCRIPTION
Use the java.util.Properties class for parsing properties for sinks
instead of a regular expression. This allows support for the full range
of legal properties (such as multiline properties).

Fixes #23